### PR TITLE
feat: add GitHub Actions workflows for DNS management

### DIFF
--- a/.github/workflows/add-dns-record.yml
+++ b/.github/workflows/add-dns-record.yml
@@ -1,0 +1,84 @@
+name: Add DNS Record
+
+on:
+  workflow_dispatch:
+    inputs:
+      domain:
+        description: 'Domain name (e.g., sdsdeliver.io)'
+        required: true
+        type: string
+      record_name:
+        description: 'DNS record name (e.g., _github-pages-challenge-sdsdeliverio)'
+        required: true
+        type: string
+      record_type:
+        description: 'DNS record type'
+        required: true
+        type: choice
+        options:
+          - TXT
+          - A
+          - AAAA
+          - CNAME
+          - MX
+        default: 'TXT'
+      record_value:
+        description: 'DNS record value/content'
+        required: true
+        type: string
+      ttl:
+        description: 'TTL (1 for auto)'
+        required: false
+        type: number
+        default: 1
+      proxied:
+        description: 'Proxied through Cloudflare'
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  add-record:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get Zone ID
+        id: get-zone
+        run: |
+          ZONE_ID=$(curl -s -X GET "https://api.cloudflare.com/client/v4/zones?name=${{ inputs.domain }}" \
+            -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
+            -H "Content-Type: application/json" | jq -r '.result[0].id')
+          echo "zone_id=$ZONE_ID" >> $GITHUB_OUTPUT
+          echo "Zone ID: $ZONE_ID"
+
+      - name: Add DNS Record
+        run: |
+          RESPONSE=$(curl -s -X POST "https://api.cloudflare.com/client/v4/zones/${{ steps.get-zone.outputs.zone_id }}/dns_records" \
+            -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
+            -H "Content-Type: application/json" \
+            --data '{
+              "type": "${{ inputs.record_type }}",
+              "name": "${{ inputs.record_name }}",
+              "content": "${{ inputs.record_value }}",
+              "ttl": ${{ inputs.ttl }},
+              "proxied": ${{ inputs.proxied }},
+              "comment": "Added via GitHub Actions"
+            }')
+          
+          echo "$RESPONSE" | jq .
+          
+          SUCCESS=$(echo "$RESPONSE" | jq -r '.success')
+          if [ "$SUCCESS" != "true" ]; then
+            echo "Failed to add DNS record"
+            exit 1
+          fi
+          
+          echo "✅ DNS record added successfully"
+          echo "Record: ${{ inputs.record_name }}.${{ inputs.domain }}"
+          echo "Type: ${{ inputs.record_type }}"
+          echo "Value: ${{ inputs.record_value }}"
+
+      - name: Verify Record
+        run: |
+          sleep 5
+          echo "Verifying DNS record..."
+          dig +short ${{ inputs.record_name }}.${{ inputs.domain }} ${{ inputs.record_type }}

--- a/.github/workflows/add-github-pages-verification.yml
+++ b/.github/workflows/add-github-pages-verification.yml
@@ -1,0 +1,61 @@
+name: Add GitHub Pages Verification
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/add-github-pages-verification.yml'
+
+jobs:
+  add-verification-record:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get sdsdeliver.io Zone ID
+        id: get-zone
+        run: |
+          ZONE_ID=$(curl -s -X GET "https://api.cloudflare.com/client/v4/zones?name=sdsdeliver.io" \
+            -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
+            -H "Content-Type: application/json" | jq -r '.result[0].id')
+          echo "zone_id=$ZONE_ID" >> $GITHUB_OUTPUT
+          echo "Zone ID: $ZONE_ID"
+
+      - name: Add GitHub Pages Verification TXT Record
+        run: |
+          RESPONSE=$(curl -s -X POST "https://api.cloudflare.com/client/v4/zones/${{ steps.get-zone.outputs.zone_id }}/dns_records" \
+            -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
+            -H "Content-Type: application/json" \
+            --data '{
+              "type": "TXT",
+              "name": "_github-pages-challenge-sdsdeliverio",
+              "content": "45c9ba69ca58e2c8a8ea5ec40c97ea",
+              "ttl": 1,
+              "proxied": false,
+              "comment": "GitHub Pages verification record"
+            }')
+          
+          echo "$RESPONSE" | jq .
+          
+          SUCCESS=$(echo "$RESPONSE" | jq -r '.success')
+          if [ "$SUCCESS" != "true" ]; then
+            ERROR=$(echo "$RESPONSE" | jq -r '.errors[0].message // "Unknown error"')
+            if [[ "$ERROR" == *"already exists"* ]]; then
+              echo "⚠️  Record already exists - skipping"
+              exit 0
+            fi
+            echo "❌ Failed to add DNS record: $ERROR"
+            exit 1
+          fi
+          
+          echo "✅ GitHub Pages verification record added successfully"
+          echo "Record: _github-pages-challenge-sdsdeliverio.sdsdeliver.io"
+          echo "Type: TXT"
+          echo "Value: 45c9ba69ca58e2c8a8ea5ec40c97ea"
+
+      - name: Verify Record
+        run: |
+          echo "Waiting for DNS propagation..."
+          sleep 10
+          echo "Verifying DNS record..."
+          dig +short _github-pages-challenge-sdsdeliverio.sdsdeliver.io TXT


### PR DESCRIPTION
## Changes
- Add workflow to add GitHub Pages verification TXT record for sdsdeliver.io
- Add generic workflow for adding DNS records via Cloudflare API
- Workflows use `CLOUDFLARE_API_TOKEN` secret for authentication

## GitHub Pages Verification
This PR adds the required TXT record for GitHub Pages domain verification:
- **Record:** `_github-pages-challenge-sdsdeliverio.sdsdeliver.io`
- **Type:** TXT
- **Value:** `45c9ba69ca58e2c8a8ea5ec40c97ea`

The workflow will automatically run on merge to main.

## Requirements
- Ensure `CLOUDFLARE_API_TOKEN` secret is set in repository settings
- Token must have DNS edit permissions for sdsdeliver.io zone